### PR TITLE
Suppress MSVC warning C4800 caused by static_cast<bool>(unsigned)

### DIFF
--- a/include/boost/crc.hpp
+++ b/include/boost/crc.hpp
@@ -1774,7 +1774,7 @@ crc_basic<Bits>::process_bits
     unsigned char const  high_bit_mask = 1u << ( CHAR_BIT - 1u );
     for ( std::size_t i = bit_length ; i > 0u ; --i, bits <<= 1u )
     {
-        process_bit( static_cast<bool>(bits & high_bit_mask) );
+      process_bit(static_cast<bool>((bits & high_bit_mask) > 0u));
     }
 }
 


### PR DESCRIPTION
The static_cast<bool> of an unsigned causes the following warning with
MSVC:

  warning C4800: "'int' : forcing value to bool 'true' or 'false' (performance warning)

Suppress the warning for the cast in question as is done in other places
of Boost.

This fixes https://svn.boost.org/trac/boost/ticket/9198
