### PR TITLE
Suppress MSVC warning C4800 about assigning from int to bool

### DIFF
--- a/include/boost/crc.hpp
+++ b/include/boost/crc.hpp
@@ -566,7 +566,7 @@ namespace detail
             remainder ^= ( new_dividend_bits & 1u ) ? high_bit_mask : 0u;
 
             // perform modulo-2 division
-            bool const  quotient = remainder & high_bit_mask;
+            bool const  quotient = !!(remainder & high_bit_mask);
 
             remainder <<= 1;
             remainder ^= quotient ? truncated_divisor : 0u;


### PR DESCRIPTION
warning C4800: "'int' : forcing value to bool 'true' or 'false' (performance warning)

Fix by double-negating the expression with !!.

Similar to PR #2, but not the same piece of code.