### PR TITLE
Fixed bug with crc_optimal computes wrong checksum.

### DIFF
--- a/include/boost/crc.hpp
+++ b/include/boost/crc.hpp
@@ -573,6 +573,9 @@ namespace detail
 
             // The quotient isn't used for anything, so don't keep it.
         }
+
+        // Clear overflowed bits
+        remainder &= std::numeric_limits<Register>::max() >> (sizeof(Register) * 8 - register_length);
     }
 
     /** \brief  Update a CRC remainder by a single bit, assuming a non-augmented


### PR DESCRIPTION
With some template parameters (such as CRC-14/DARC, CRC-24/BLE), crc_optimal computes wrong checksum.

```C++
char data[9] = { '1', '2', '3', '4', '5', '6', '7', '8', '9' };
boost::crc_basic  <14> crc14_darc_basic(0x805, 0x0000, 0x0000, true, true);
boost::crc_optimal<14,                  0x805, 0x0000, 0x0000, true, true> crc14_darc_optimal;
crc14_darc_basic  .process_bytes(data, sizeof(data));
crc14_darc_optimal.process_bytes(data, sizeof(data));
auto crc14_darc_value1 = crc14_darc_basic  .checksum(); // 0x082D
auto crc14_darc_value2 = crc14_darc_optimal.checksum(); // 0x3FF4 (!)
```