### PR TITLE
Initialize result in make_partial_xor_products_table to avoid warning

### DIFF
--- a/include/boost/crc.hpp
+++ b/include/boost/crc.hpp
@@ -968,7 +968,7 @@ namespace detail
     make_partial_xor_products_table( int register_length, Register
      truncated_divisor, bool reflect )
     {
-        boost::array<Register, ( UINTMAX_C(1) << SubOrder )>  result;
+        boost::array<Register, ( UINTMAX_C(1) << SubOrder )>  result = { 0 };
 
         // Loop over every possible dividend value
         for ( typename boost::uint_t<SubOrder + 1>::fast  dividend = 0u;


### PR DESCRIPTION
This fixes the following warning when compiling with MSVC:

`crc.hpp(984) : warning C4701: potentially uninitialized local variable 'result' used`

This PR is identical to https://github.com/boostorg/crc/pull/6.