### PR TITLE
Reflect a8dd4858 to augmented_crc_modulo_word_update() too

### DIFF
--- a/include/boost/crc.hpp
+++ b/include/boost/crc.hpp
@@ -675,7 +675,7 @@ namespace detail
         // The natural reading order for division is highest digit/bit first.
         // The "reflect" parameter switches this.  However, building a bit mask
         // for the lowest bit is the easiest....
-        new_dividend_bits = reflect_optionally( new_dividend_bits, not reflect,
+        new_dividend_bits = reflect_optionally( new_dividend_bits, !reflect,
          word_length );
 
         // Perform modulo-2 division for each new dividend input bit


### PR DESCRIPTION
The commit a8dd4858 replaced the operator "not" by the conventional "!" in crc_modulo_word_update() for MSVC. But "not" is still used for augmented_crc_modulo_word_update(). This patch replaces the "not" in augmented_crc_modulo_word_update() by "!".