### PR TITLE
Standalone mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,18 +7,32 @@ cmake_minimum_required(VERSION 3.5...3.16)
 
 project(boost_crc VERSION "${BOOST_SUPERPROJECT_VERSION}" LANGUAGES CXX)
 
+include(CMakeDependentOption)
+
+cmake_dependent_option(BOOST_CRC_STANDALONE "Use Boost.Crc in standalone mode" ON "NOT BOOST_SUPERPROJECT_VERSION" OFF)
+
+message(STATUS "Boost.Crc: standalone mode ${BOOST_CRC_STANDALONE}")
+
 add_library(boost_crc INTERFACE)
 add_library(Boost::crc ALIAS boost_crc)
 
 target_include_directories(boost_crc INTERFACE include)
 
-target_link_libraries(boost_crc
-  INTERFACE
-    Boost::array
-    Boost::config
-    Boost::integer
-    Boost::type_traits
-)
+if(BOOST_CRC_STANDALONE)
+
+    target_compile_definitions(boost_crc INTERFACE BOOST_CRC_STANDALONE=1)
+
+else()
+
+    target_link_libraries(boost_crc
+      INTERFACE
+        Boost::array
+        Boost::config
+        Boost::integer
+        Boost::type_traits
+    )
+
+endif()
 
 if(BUILD_TESTING AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/CMakeLists.txt")
 


### PR DESCRIPTION
# Standalone mode

Boost.Crc has a few boost dependencies, most of which can be substituted with STD library's analogs. So it worth make the library more portable by implementing self-sufficient standalone mode in which Boost.Crc effectively becomes single-header library. In this mode library header can be easily copy-pasted where needed and used as is without boost baggage (bcp copies 425 headers with total of 93718 LOC in boost v1.82.0).

CAUTION: In this mode most of platform specific workarounds and tweaks are not ported, so it might work worse that in normal mode on some exotic platforms.

TODO:

- [X] Add standalone mode in the header
- [X] Add option in CMakeLists.txt using Boost.Math as a reference
- [ ] Somehow test it
- [ ] Update documentation according to the new changes

## Testing

Testing part is tricky. There are several complications at once:
1. this project is not set up to be modularly autotested on CI. It is tested only as part of full boost bundle in a single configuration
2. new BOOST_CRC_STANDALONE alters existing Boost::crc target, so new mode can't be tested along with normal mode, separate configuration is needed
3. existing tests are heavily depend on boost libraries and Jamfile configuration

I think testing part should be skipped for now and be done in the separate PR. And I need to research infrastructure of other libraries to find tips how it can be done.

To ensure it works, I suppose some not over-complicated test on godbolt should be enough.

# Documentation

Documentation is very tricky because it is done in quickbook format which I don't know and I have no idea how building and commit of resulting documentation is done. Is it somehow automated or I have to manually run some jam target and then commit the result? It seems I need to find documentation related commits for hints. 

